### PR TITLE
fix: stop publishing container ports on the host

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,22 @@
+# Local development only.
+# Publishes container ports on the host so services are reachable at localhost.
+# Docker Compose loads this file automatically on `docker compose up`.
+# Deployment platforms that pass an explicit `-f docker-compose.yaml` ignore it,
+# so nothing is exposed on the host in production.
+services:
+  db:
+    ports:
+      - "5432:5432"
+
+  minio:
+    ports:
+      - "9000:9000"
+      - "9001:9001" # MinIO console (UI)
+
+  backend-api:
+    ports:
+      - "8000:8000"
+
+  frontend:
+    ports:
+      - "3000:3000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,8 +45,6 @@ services:
     image: postgres:15
     container_name: postgres_db
     restart: always
-    ports:
-      - "5432:5432"
     environment:
       <<: *db-env
       TZ: America/Argentina/Buenos_Aires
@@ -63,9 +61,6 @@ services:
   minio:
     image: minio/minio:latest
     container_name: minio-server
-    ports:
-      - "9000:9000"
-      - "9001:9001" # Puerto para la consola de MinIO (UI)
     environment:
         <<: *minio-env
     volumes:
@@ -90,8 +85,6 @@ services:
       <<: [*minio-env, *db-env, *jwt-env]
       # JWT & Cookies
       
-    ports:
-      - "8000:8000"
     depends_on:
       db:
         condition: service_healthy
@@ -147,8 +140,6 @@ services:
       ORIGIN: "${ORIGIN}"
       BODY_SIZE_LIMIT: 104857600 # 100MB in bytes for video uploads
 
-    ports:
-      - "3000:3000"
     networks:
       - siat_network
     depends_on:


### PR DESCRIPTION
## Problem

Deployment to the shared server fails:

    Bind for 0.0.0.0:8000 failed: port is already allocated

`docker-compose.yaml` publishes five container ports on the host
(5432, 8000, 9000, 9001, 3000). Port 8000 is already used by another
application on that machine, so `backend-api` never starts.

Two further consequences on a shared host:

- PostgreSQL and MinIO are reachable on the server's public IP.
- The other four ports are free today. Any future deployment that
  claims 3000 or 9000 breaks this one the same way.

## Why publishing is not needed

The reverse proxy does not use the published host ports. It joins the
containers on a shared Docker network and targets the container port
directly:

    traefik.http.services.<router>.loadbalancer.server.port=8000

## Changes

- `docker-compose.yaml`: remove all `ports:` entries (-9 lines).
- `docker-compose.override.yaml`: new file, restores the same
  mappings for local development.

## Local development is unchanged

`docker compose up` loads the override automatically, so
`localhost:3000` and `localhost:9001` work as before. Deployment
platforms invoke Compose with an explicit `-f docker-compose.yaml`,
which skips override files.

Please keep this file committed — it is not a personal local override.

## Verification

    docker compose config                        -> 5 published ports
    docker compose -f docker-compose.yaml config -> 0 published ports
