### PR TITLE
fix: do not bind-mount the source tree in production

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,8 +1,9 @@
 # Local development only.
-# Publishes container ports on the host so services are reachable at localhost.
+# Publishes container ports on the host and mounts the source tree into the
+# backend containers for live reload.
 # Docker Compose loads this file automatically on `docker compose up`.
 # Deployment platforms that pass an explicit `-f docker-compose.yaml` ignore it,
-# so nothing is exposed on the host in production.
+# so production runs the built image untouched.
 services:
   db:
     ports:
@@ -16,6 +17,12 @@ services:
   backend-api:
     ports:
       - "8000:8000"
+    volumes:
+      - ./backend:/app
+
+  backend-worker:
+    volumes:
+      - ./backend:/app
 
   frontend:
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,7 +93,6 @@ services:
     networks:
       - siat_network
     volumes:
-      - ./backend:/app
       - model_weights:/app/app/modelo
 
   backend-worker:
@@ -119,7 +118,6 @@ services:
     networks:
       - siat_network
     volumes:
-      - ./backend:/app
       - model_weights:/app/app/modelo
     # deploy:
     #   resources:


### PR DESCRIPTION
## Problem

`backend-api` and `backend-worker` crash-loop on deploy:

    /bin/bash: /app/api-entrypoint.sh: Permission denied
    /bin/bash: /app/worker-entrypoint.sh: Permission denied

Both services bind-mount `./backend` over `/app`. On the deployment
host the checkout is owned by the deployment user:

    -rwxr-x--- 1 coolify coolify api-entrypoint.sh

The container runs as `www-data` (set by the Dockerfile). That user is
neither the owner nor in the group, so it falls through to "other",
which has no permissions at all. The executable bit is present — the
mismatch is ownership, not mode.

The frontend then fails too, because it cannot resolve `backend-api`:

    Error: getaddrinfo EAI_AGAIN backend-api

## Why the mount does not belong in production

It shadows `/app` in the image, discarding both the `COPY` of the
application code and the `chown -R www-data:www-data /app` that the
Dockerfile applies. The container ends up running a raw checkout
instead of the image that was just built.

## Changes

- `docker-compose.yaml`: drop `./backend:/app` from `backend-api` and
  `backend-worker`. The `model_weights` volume is unchanged.
- `docker-compose.override.yaml`: restore the mount for local development.

## Local development is unchanged

`docker compose up` merges the override, so the source tree is still
mounted and code changes still apply without a rebuild.

## Verification

    docker compose config
      backend-api    -> model_weights volume + bind ./backend:/app
      backend-worker -> model_weights volume + bind ./backend:/app

    docker compose -f docker-compose.yaml config
      no bind mounts
