### PR TITLE
fix: upload the processed video to the bucket

### DIFF
--- a/backend/app/command/process_command.py
+++ b/backend/app/command/process_command.py
@@ -211,6 +211,13 @@ def process_next_task() -> bool:
             typer.echo("Subiendo el archivo data_obj_history.json al bucket...")
             with open(local_data_obj_history_path, 'rb') as f:
                 bucket_service.upload(f, object_name=bucket_data_obj_history_path, content_type="application/json")
+
+            # Subir el video procesado al bucket
+            typer.echo("Subiendo el video procesado al bucket...")
+            _, input_ext = os.path.splitext(input_video_path)
+            local_processed_video_path = os.path.join(output_dir, f"processed{input_ext}")
+            with open(local_processed_video_path, 'rb') as f:
+                bucket_service.upload(f, object_name=bucket_video_path, content_type="video/mp4")
             
             # Paso 7: Crear el objeto de inferencia
             inference = inference_service.create_inference(


### PR DESCRIPTION
## Problem

After a task is processed, the review page shows an empty video player.

The bucket only ever contains two objects per task:

    task/1/<hash>.mp4
    task/1/<hash>_data_obj_history.json

`process_command.py` builds the processed video key and stores it on the
inference record:

    195:  bucket_video_path = f"task/{id}/{hash}_processed.mp4"
    222:  url_video_processed=bucket_video_path

but the only upload in that flow is the JSON:

    213:  bucket_service.upload(f, object_name=bucket_data_obj_history_path, ...)

So `url_video_processed` points at an object that was never uploaded.
MinIO answers `NoSuchKey` and the player renders blank.

`process.py` does produce the file — it writes `processed<ext>` into the
same directory the command already resolves to read the JSON results —
it is simply left in the temporary folder and discarded.

## Changes

`backend/app/command/process_command.py`: upload the processed video to
the key already recorded on the inference record.

## Failure behaviour

The video is read with `open()`, like the JSON result files. A missing
video now raises `FileNotFoundError` and is handled by the existing
error path, instead of the task being marked `PROCESSED` with a
reference to a file that does not exist.

## Not covered here

The task also produced an empty `data_obj_history.json` and zero
counts, with `process.py` exiting 0. That is a separate problem and
needs to be reproduced with the worker logs open.
