### PR TITLE
feat: write the processed video to disk

### DIFF
--- a/backend/app/modelo/process.py
+++ b/backend/app/modelo/process.py
@@ -544,7 +544,26 @@ class ObjectTracker:
 
         act_frame = 0  # Contador de frames leídos (no de frames procesados por YOLO)
         print(f"Procesando video: {video_path} (dimensiones: {w}x{h}, FPS: {fps})")
+
+        # Escritor del video de salida. Se abre solo si se pidió una ruta.
+        writer = None
         if output_video_path:
+            os.makedirs(os.path.dirname(output_video_path) or ".", exist_ok=True)
+            # FPS de respaldo: algunos contenedores reportan 0 y VideoWriter lo rechaza.
+            out_fps = fps if fps and fps > 0 else 25
+            writer = cv2.VideoWriter(
+                output_video_path,
+                cv2.VideoWriter_fourcc(*"mp4v"),
+                out_fps,
+                (w, h),
+            )
+            if not writer.isOpened():
+                writer.release()
+                cap.release()
+                raise RuntimeError(
+                    f"No se pudo abrir el escritor de video en {output_video_path} "
+                    f"(codec mp4v, {w}x{h} @ {out_fps} FPS)."
+                )
             print(f"Guardando video procesado en: {output_video_path}")
         else:
             print(
@@ -592,6 +611,9 @@ class ObjectTracker:
             masked_for_output = self._apply_exclusion_mask(frame)
             processed_frame = self.process_frame(masked_for_output, results, act_frame)
 
+            if writer is not None:
+                writer.write(processed_frame)
+
             # Mostrar el frame procesado SOLO SI display_video es True
             if display_video:
                 cv2.imshow("Video", processed_frame)
@@ -613,6 +635,8 @@ class ObjectTracker:
 
         # Liberar recursos
         cap.release()
+        if writer is not None:
+            writer.release()
 
         # Destruir ventanas SOLO si se mostraron
         if display_video:


### PR DESCRIPTION
## Problem

The worker uploads the processed video from the path `process.py` is
expected to write, and fails:

    [Errno 2] No such file or directory:
    '/tmp/siat_temp/temp_video_2/processed.mp4'

`ObjectTracker.run()` takes `output_video_path`, but the only thing it
does with it is print it:

    547:  if output_video_path:
    548:      print(f"Guardando video procesado en: {output_video_path}")

There is no `VideoWriter` anywhere in the file. Frames are read,
tracked, annotated by `process_frame()`, optionally shown on screen —
and then discarded. The processed video was never written.

## Changes

`backend/app/modelo/process.py`, in `ObjectTracker.run()`:

- open a `cv2.VideoWriter` when `output_video_path` is given, using the
  dimensions and FPS already read from the source
- write each processed frame
- release the writer alongside the capture

Two details: the output directory is created if missing, and the FPS
falls back to 25 when the container reports 0, which `VideoWriter`
rejects.

## Failure behaviour

The writer is checked with `isOpened()` and raises if it cannot be
created. Without that check OpenCV accepts every `write()` call and
silently produces nothing, which is the failure mode this change exists
to remove.

## Verification

The `mp4v` codec was tested in a container matching the backend base
image (`python:3.11-slim`, `libgl1`, `libglib2.0-0`, `opencv-python`)
and natively on macOS with `opencv-python` 4.10:

    isOpened: True
    file written: 42884 bytes
    re-readable: True, 50 frames

## Note

Processing is now slower and uses more temporary disk, since each frame
is encoded and the output video is kept until it is uploaded.
