### PR TITLE
fix: do not mount a volume over the model directory

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,8 +92,6 @@ services:
         condition: service_healthy
     networks:
       - siat_network
-    volumes:
-      - model_weights:/app/app/modelo
 
   backend-worker:
     build:
@@ -117,8 +115,6 @@ services:
         condition: service_started
     networks:
       - siat_network
-    volumes:
-      - model_weights:/app/app/modelo
     # deploy:
     #   resources:
     #     reservations:
@@ -152,6 +148,5 @@ networks:
 volumes:
   postgres_data:
   minio_data:
-  model_weights:
 
 


### PR DESCRIPTION
## Problem

Changes to `backend/app/modelo/` never reach the running container.

The compose mounts a named volume over the directory:

    volumes:
      - model_weights:/app/app/modelo

That directory is not weights-only. It holds `process.py`, `run.py`,
`post_process.py` and `botsort_custom.yaml` next to `model-v5.pt`.

Docker copies image content into a named volume only when the volume is
empty, at creation. Afterwards the volume wins. Inside the container:

    -rw-r--r-- 1 www-data www-data 35205 Aug 27 22:58 process.py

That is the volume's copy, while later deployments built images
containing newer versions of the same file. It is why the change in #5
is deployed but never executed.

The same shadowing applies to local development, where the volume also
sits on top of the bind-mounted source tree.

## Why the volume is not needed

- `model-v5.pt` is tracked in git (6.5 MB) and ships in the image.
- Nothing writes to that directory at runtime — `YOLO_CONFIG_DIR` and
  `MPLCONFIGDIR` already point elsewhere.

## Changes

`docker-compose.yaml`: drop the `model_weights` mount from
`backend-api` and `backend-worker`, and the volume declaration.

## Effect

    docker compose config
      backend-api    -> bind ./backend:/app
      backend-worker -> bind ./backend:/app

    docker compose -f docker-compose.yaml config
      no volumes on either service

Production runs the image as built. Local development keeps the bind
mount, and edits under `backend/app/modelo/` now take effect instead of
being shadowed.

## Note

The existing `model_weights` volume becomes orphaned and can be removed.
Anyone who placed weights there by hand, outside git, should copy them
into the repository first.
