### PR TITLE
fix: encode the processed video as H.264

### DIFF
--- a/backend/app/modelo/process.py
+++ b/backend/app/modelo/process.py
@@ -10,6 +10,8 @@ import sys # Importar sys para manejar la salida en la terminal
 import argparse # Importar argparse para manejar argumentos de línea de comandos
 import ast # Para convertir strings a listas/arrays
 import os # Importar os para operaciones de sistema de archivos (rutas)
+import subprocess # Para encodear el video de salida con ffmpeg
+import imageio_ffmpeg # Provee un ffmpeg estático con soporte de H.264
 import json
 
 # Importar torch para la detección de GPU
@@ -546,24 +548,26 @@ class ObjectTracker:
         print(f"Procesando video: {video_path} (dimensiones: {w}x{h}, FPS: {fps})")
 
         # Escritor del video de salida. Se abre solo si se pidió una ruta.
+        # Los frames se encodean con ffmpeg en lugar de cv2.VideoWriter: el ffmpeg
+        # embebido en opencv-python no incluye libx264, y sin H.264 el video no se
+        # reproduce en los navegadores, que es donde se revisa el resultado.
         writer = None
         if output_video_path:
             os.makedirs(os.path.dirname(output_video_path) or ".", exist_ok=True)
-            # FPS de respaldo: algunos contenedores reportan 0 y VideoWriter lo rechaza.
+            # FPS de respaldo: algunos contenedores reportan 0.
             out_fps = fps if fps and fps > 0 else 25
-            writer = cv2.VideoWriter(
-                output_video_path,
-                cv2.VideoWriter_fourcc(*"mp4v"),
-                out_fps,
-                (w, h),
+            writer = subprocess.Popen(
+                [
+                    imageio_ffmpeg.get_ffmpeg_exe(),
+                    "-y", "-loglevel", "error",
+                    "-f", "rawvideo", "-pix_fmt", "bgr24",
+                    "-s", f"{w}x{h}", "-r", str(out_fps), "-i", "-",
+                    "-an", "-c:v", "libx264", "-pix_fmt", "yuv420p",
+                    "-movflags", "+faststart",
+                    output_video_path,
+                ],
+                stdin=subprocess.PIPE,
             )
-            if not writer.isOpened():
-                writer.release()
-                cap.release()
-                raise RuntimeError(
-                    f"No se pudo abrir el escritor de video en {output_video_path} "
-                    f"(codec mp4v, {w}x{h} @ {out_fps} FPS)."
-                )
             print(f"Guardando video procesado en: {output_video_path}")
         else:
             print(
@@ -612,7 +616,12 @@ class ObjectTracker:
             processed_frame = self.process_frame(masked_for_output, results, act_frame)
 
             if writer is not None:
-                writer.write(processed_frame)
+                if processed_frame.shape[:2] != (h, w):
+                    raise RuntimeError(
+                        f"El frame {act_frame} mide {processed_frame.shape[1]}x{processed_frame.shape[0]}, "
+                        f"se esperaba {w}x{h}."
+                    )
+                writer.stdin.write(processed_frame.tobytes())
 
             # Mostrar el frame procesado SOLO SI display_video es True
             if display_video:
@@ -636,7 +645,11 @@ class ObjectTracker:
         # Liberar recursos
         cap.release()
         if writer is not None:
-            writer.release()
+            writer.stdin.close()
+            if writer.wait() != 0:
+                raise RuntimeError(
+                    f"ffmpeg terminó con código {writer.returncode} al escribir {output_video_path}."
+                )
 
         # Destruir ventanas SOLO si se mostraron
         if display_video:


### PR DESCRIPTION
## Problem

The review page shows an empty player, although the processed video is
generated and uploaded. In the bucket:

    task/4/<hash>_processed.mp4    68874210

The file carries an `esds` atom and no `avcC`: it is MPEG-4 Part 2,
written by `cv2.VideoWriter` with the `mp4v` fourcc. Browsers decode
H.264, VP8/VP9 and AV1 — not MPEG-4 Part 2.

## Why the fourcc cannot be changed

The FFmpeg bundled with `opencv-python` has no H.264 encoder; `libx264`
is GPL and excluded from the wheel. Tested in a container matching the
backend base image:

    avc1   isOpened=False   0 bytes
    H264   isOpened=False   0 bytes
    x264   isOpened=False   0 bytes
    mp4v   isOpened=True    -> esds

OpenCV reports it directly:

    FFMPEG: tag 'H264' is not supported with codec id 27
    FFMPEG: fallback to use tag 'avc1'

## Changes

`backend/app/modelo/process.py`: replace `cv2.VideoWriter` with a
FFmpeg subprocess reading raw BGR frames from stdin and encoding
`libx264` / `yuv420p` / `+faststart`. One encode, no intermediate file.

No new dependency: `imageio[ffmpeg]` is already in `requirements.txt`
and installs `imageio-ffmpeg`, which ships a static FFmpeg 7.0.2 with
libx264.

## Failure behaviour

A non-zero exit from FFmpeg raises, as does a frame whose dimensions do
not match the ones the encoder was opened with — that mismatch would
otherwise corrupt the output silently.

## Verification

In a container matching the backend base image:

    ffmpeg 7.0.2-static, libx264 available: True
    returncode: 0
    avcC=True  esds=False
