### PR TITLE
fix: run inference at the video's native resolution

### DIFF
--- a/backend/app/command/process_command.py
+++ b/backend/app/command/process_command.py
@@ -115,6 +115,13 @@ def process_next_task() -> bool:
                 "--names_polygons_out", str(names_polygons_out),
                 "--no_display",
             ]
+
+            # Resolución de inferencia. Sin definir, process.py usa la nativa del
+            # video. Permite bajarla para acelerar el procesamiento a costa de
+            # detectar menos objetos.
+            imgsz = os.getenv("YOLO_IMGSZ")
+            if imgsz:
+                command.append(f"--imgsz={imgsz}")
             
             typer.echo("Ejecutando el script `process.py`...")
             typer.echo(f"Comando: {' '.join(command)}")

--- a/backend/app/modelo/process.py
+++ b/backend/app/modelo/process.py
@@ -515,7 +515,7 @@ class ObjectTracker:
         
         return frame
 
-    def run(self, video_path: str, max_frames: Optional[int] = None, output_video_path: Optional[str] = None, display_video: bool = True):
+    def run(self, video_path: str, max_frames: Optional[int] = None, output_video_path: Optional[str] = None, display_video: bool = True, imgsz: Optional[int] = None):
         """
         Ejecuta el proceso de seguimiento de objetos en un video.
 
@@ -544,8 +544,15 @@ class ObjectTracker:
         # Si el número de frames es incierto o 0, deshabilitar el progreso en porcentaje
         progress_enabled = frames_to_process > 0 and frames_to_process != float('inf')
 
+        # Resolución de inferencia. Sin este valor Ultralytics usa 640, que sobre
+        # material aéreo reduce los vehículos hasta hacerlos indetectables: el
+        # seguimiento no llega a confirmar ninguna identidad y el historial queda
+        # vacío. Por defecto se infiere a la resolución nativa del video.
+        infer_imgsz = imgsz if imgsz else max(32, ((max(w, h) + 31) // 32) * 32)
+
         act_frame = 0  # Contador de frames leídos (no de frames procesados por YOLO)
         print(f"Procesando video: {video_path} (dimensiones: {w}x{h}, FPS: {fps})")
+        print(f"Resolución de inferencia: {infer_imgsz}")
 
         # Escritor del video de salida. Se abre solo si se pidió una ruta.
         # Los frames se encodean con ffmpeg en lugar de cv2.VideoWriter: el ffmpeg
@@ -608,7 +615,7 @@ class ObjectTracker:
             # Realizar seguimiento de objetos
             # Aplicar máscara de exclusión antes de inferir
             masked_for_inference = self._apply_exclusion_mask(frame)
-            results = self.model.track(masked_for_inference, conf=0.3, iou=0.6, persist=True, verbose=False, agnostic_nms=True, tracker=self.tracker_path)
+            results = self.model.track(masked_for_inference, conf=0.3, iou=0.6, persist=True, verbose=False, agnostic_nms=True, imgsz=infer_imgsz, tracker=self.tracker_path)
             
             # Procesar el frame (dibujar zonas, BBs, etc.)
             # También aplicar la máscara al frame de salida para que "no se vea"
@@ -707,6 +714,10 @@ if __name__ == "__main__":
              '"video.mp4" y el modelo es "model.pt", la salida será "video_dir/model/video_processed.mp4".'
     )
     parser.add_argument(
+        '--imgsz', type=int, default=None,
+        help='Resolución de inferencia. Por defecto, la resolución nativa del video.'
+    )
+    parser.add_argument(
         '--max_frames', '-f', type=int, default=None,
         help='Número máximo de frames a procesar. Por defecto, se procesa el video completo.'
     )
@@ -752,7 +763,8 @@ if __name__ == "__main__":
         video_path=args.input_video_path, 
         max_frames=args.max_frames, 
         output_video_path=final_output_video_path,
-        display_video=show_video_window
+        display_video=show_video_window,
+        imgsz=args.imgsz
     )
 
     # 5. Guardar resultados en archivos JSON


### PR DESCRIPTION
## Problem

Processing completes, but the review page shows every counter at zero,
`data_obj_history.json` is `{}` and the processed video has no boxes on
any vehicle — while the footage clearly shows traffic.

`process.py` calls `model.track()` without `imgsz`, so Ultralytics falls
back to its 640 default. The footage is 1920x1080: a threefold
downscale before inference.

Measured over a 141-frame clip with the deployed model and the same
confidence, IoU and tracker settings:

    imgsz=640    19 detections    19/141 frames     0 track ids
    imgsz=1920   1401 detections  141/141 frames   18 track ids

At 640 the detections are too sporadic for BoTSORT to confirm an
identity, so no track ids are ever assigned. `data_obj_history` is keyed
by track id, which leaves it empty; the counters read from it, so they
stay at zero; and boxes are drawn per tracked object, so none appear.
One cause, four symptoms.

This is not environment specific — the 640 default applies everywhere,
which matches the same zeros being reported on local setups.

## Changes

- `process.py`: infer at the video's native resolution by default,
  rounded up to a multiple of 32, and accept `--imgsz` to override it.
  The value is logged at startup.
- `process_command.py`: forward `YOLO_IMGSZ` when set, so the
  resolution can be tuned without a code change.

## Cost

Native resolution is nine times the pixels of 640 per frame, and the
deployment has no GPU. `YOLO_IMGSZ` exists to trade accuracy for
processing time without redeploying code.

## Verification

Running `process.py` end to end on the same clip:

    Resolución de inferencia: 1920
    objects in data_obj_history: 5     (previously 0)

## Scope

This restores detection. It does not by itself produce non-zero
counters: a route is only counted when a vehicle enters through one
zone and leaves through another within the clip, and this 4.7 second
sample contains no complete route. Validating the counting needs longer
footage.
